### PR TITLE
VER-1321: Significant performance improvement for Tests

### DIFF
--- a/src/main/scala/uk/gov/hmrc/secure/GCMEncrypterDecrypter.scala
+++ b/src/main/scala/uk/gov/hmrc/secure/GCMEncrypterDecrypter.scala
@@ -29,7 +29,6 @@ class GCMEncrypterDecrypter(private val key: Array[Byte], private val associated
 
   import GCMEncrypterDecrypter._
 
-  private lazy val secureRNG = initSecureRNG()
   private lazy val keyParam: KeyParameter = new KeyParameter(key)
 
   def encrypt(data: Array[Byte]): String = {
@@ -68,6 +67,14 @@ class GCMEncrypterDecrypter(private val key: Array[Byte], private val associated
     if (associatedText == null) throw new IllegalStateException("There is no Associated Text!")
   }
 
+}
+
+object GCMEncrypterDecrypter {
+  final val MAC_SIZE = 128
+  final val NONCE_SIZE = MAC_SIZE / 8
+
+  private lazy val secureRNG = initSecureRNG()
+
   private def initSecureRNG(): SecureRandom = {
     var random: SecureRandom = null
     try {
@@ -82,9 +89,4 @@ class GCMEncrypterDecrypter(private val key: Array[Byte], private val associated
     random
   }
 
-}
-
-object GCMEncrypterDecrypter {
-  final val MAC_SIZE = 128
-  final val NONCE_SIZE = MAC_SIZE / 8
 }


### PR DESCRIPTION
In the tests of [identity-verification-frontend](https://github.com/hmrc/identity-verification-frontend), we make use of `fakeApplication()` which comes in via [GuiceOneAppPerSuite](https://www.playframework.com/documentation/2.7.0/api/scala/org/scalatestplus/play/guice/GuiceOneAppPerSuite.html) to create an instance of our Play Server.

Via dependency injection, this internally instantiates a new [GCMEncrypterDecrypter](https://github.com/hmrc/secure/blob/master/src/main/scala/uk/gov/hmrc/secure/GCMEncrypterDecrypter.scala) instance which internally creates a new [SecureRandom](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) instance and generates a secure seed.

It very much appears that the original developers of [GCMEncrypterDecrypter](https://github.com/hmrc/secure/blob/master/src/main/scala/uk/gov/hmrc/secure/GCMEncrypterDecrypter.scala) had intended for this class (and it's internal [SecureRandom](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) instance) to be a **JVM-wide Singleton** and they would have every reason to do this because [SecureRandom](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) is very slow at generating random seeds, [most especially on Linux machines](https://stackoverflow.com/questions/137212/how-to-deal-with-a-slow-securerandom-generator). In the case of Play applications running in production this will be true, it will be a singleton and all is well.

However, when running SBT tests, with `fakeApplication()` and [GuiceOneAppPerSuite](https://www.playframework.com/documentation/2.7.0/api/scala/org/scalatestplus/play/guice/GuiceOneAppPerSuite.html), what this does is cause a new instance of [GCMEncrypterDecrypter](https://github.com/hmrc/secure/blob/master/src/main/scala/uk/gov/hmrc/secure/GCMEncrypterDecrypter.scala) to be re-created for every Spec/Suite, along with it's internal [SecureRandom](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) instance.

That works, but that then causes a **major performance slow down** when running tests.

There is no `GuiceOneAppPerJVM` per-se and even if there was, it would be best that we didn't use that as we'd want to clear all Play state for each Spec/Suite.

However, we (and probably others) could do with [GCMEncrypterDecrypter](https://github.com/hmrc/secure/blob/master/src/main/scala/uk/gov/hmrc/secure/GCMEncrypterDecrypter.scala) being a JVM-wide singleton across all Specs/Suites - which is what this Pull Request intends to do.

I haven't added or removed any code, but instead have shifted your creation of the [SecureRandom](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) instance and seed generation from the class area to the object area, which ensures that the most time-expensive code is only ran once JVM-wide.

I have tested this locally, trying to repeatedly re-create new instances of [GCMEncrypterDecrypter](https://github.com/hmrc/secure/blob/master/src/main/scala/uk/gov/hmrc/secure/GCMEncrypterDecrypter.scala) and encrypt some data, using the following code:

```scala
object TestApp extends App {

  val a = System.currentTimeMillis()
  for { i <- 0 to 50 } {
    val cipher = new GCMEncrypterDecrypter("12345678901234561234567890987654".getBytes, "".getBytes)
    cipher.encrypt("hello world".getBytes())
    println("still working ...")
  }
  val b = System.currentTimeMillis()
  println("took " + (b - a) + " ms")

}
```

Without this patch, you'll see (certainly on Linux and MacOS) that it can take an enormous amount of time to create new instances, where as with this patch it is of an order of magnitude faster.

Please see [VER-1321](https://jira.tools.tax.service.gov.uk/browse/VER-1321), for further analysis and findings.